### PR TITLE
Gunicorn configuration parameters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   application:
     build: ./${APP_FOLDER}
-    command: gunicorn -c gunicorn.ini.py ${FLASK_APP}:app
+    command: gunicorn --bind 0.0.0.0:5000 --workers 3 ${FLASK_APP}:app
     environment:
       - FLASK_ENV=${FLASK_ENV}
     ports:

--- a/src/gunicorn.ini.py
+++ b/src/gunicorn.ini.py
@@ -1,7 +1,0 @@
-# Gunicorn configuration file.
-# This file can be used from the Gunicorn cli with the ``-c`` paramater.
-# Eg. ``gunicorn -c <config_file>``
-import multiprocessing
-
-bind = "0.0.0.0:5000"
-workers = multiprocessing.cpu_count() * 2 + 1


### PR DESCRIPTION
Remove the Gunicorn configuration file to make it simpler, instead directly pass the parameters in the docker-compose command.

Also removes the formula `multiprocessing.cpu_count() * 2 + 1` to calculate the number of workers. Indeed, as the app is running in a Docker container, this formula could lead to some issues (see https://bugs.python.org/issue36054).