### PR TITLE
fix on ssl certs auto-renew [issue #24]

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,7 +2,8 @@
 FROM nginx:1.19-alpine
 
 # Install certbot for letsencrypt certificates
-RUN apk add --no-cache certbot
+# Install also an init handler for alpine cron
+RUN apk add --no-cache certbot openrc busybox-initscripts
 
 # Replace existing files by our own configs
 RUN rm /etc/nginx/nginx.conf && rm /etc/nginx/conf.d/default.conf
@@ -25,8 +26,8 @@ ENV DOLLAR='$'
 # Substitute contents and write a new application.conf file, which is imported
 # by nginx.conf
 RUN envsubst \
-      </etc/nginx/conf.d/flask_app.conf \
-      >/etc/nginx/conf.d/application.conf \
+  </etc/nginx/conf.d/flask_app.conf \
+  >/etc/nginx/conf.d/application.conf \
   && rm /etc/nginx/conf.d/flask_app.conf
 
 # Directory needed for LetEncrypt certificates renewal

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -26,8 +26,8 @@ ENV DOLLAR='$'
 # Substitute contents and write a new application.conf file, which is imported
 # by nginx.conf
 RUN envsubst \
-  </etc/nginx/conf.d/flask_app.conf \
-  >/etc/nginx/conf.d/application.conf \
+      </etc/nginx/conf.d/flask_app.conf \
+      >/etc/nginx/conf.d/application.conf \
   && rm /etc/nginx/conf.d/flask_app.conf
 
 # Directory needed for LetEncrypt certificates renewal

--- a/nginx/bin/entrypoint.sh
+++ b/nginx/bin/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 certbot certonly --standalone -d $1 --email $2 -n --agree-tos --expand
-/usr/sbin/nginx -g "daemon off;"
-/usr/sbin/crond -f -d 8 &
+/usr/sbin/crond -f &
+/usr/sbin/nginx -g "daemon off;" #this call is blocking so it should be in last line

--- a/nginx/bin/entrypoint.sh
+++ b/nginx/bin/entrypoint.sh
@@ -2,4 +2,4 @@
 
 certbot certonly --standalone -d $1 --email $2 -n --agree-tos --expand
 /usr/sbin/crond -f &
-/usr/sbin/nginx -g "daemon off;" #this call is blocking so it should be in last line
+/usr/sbin/nginx -g "daemon off;"  # this is run in the foreground, so need to be last


### PR DESCRIPTION
Closes: https://github.com/smallwat3r/docker-nginx-gunicorn-flask-letsencrypt/issues/24

There was a blocking call to nginx in _entrypoint.sh_ file before the execution of `crond -f`. Also there were some missing packages to make alpine crons work in _Dockerfile_.